### PR TITLE
HeartBeat-Shader "Programming" Complete

### DIFF
--- a/Assets/Shader/HeartBeat.gdshader
+++ b/Assets/Shader/HeartBeat.gdshader
@@ -2,9 +2,13 @@ shader_type canvas_item;
 uniform vec2 playerPos;
 uniform float radius;
 uniform sampler2D objectMap;
+uniform float objectIntensity;
 uniform vec4 objectColor;
+uniform float darknessIntesity;//linear interpolation between darkness and light, closer to one more dark shade, closer to 0 more light
 uniform vec4 darkNessColor;
 const int maxStep = 32;
+
+uniform float heartbeat = 0; //this is obviosuly the heartbeat
 
 //these values seem to work pretty well for the raycast, play around with them to find better if you want though
 const float minStepD = .5;
@@ -17,21 +21,22 @@ uniform sampler2D SCREEN_TEXTURE : hint_screen_texture, filter_linear;
 void fragment() {
 	//below retrieves current pixel position
 	vec2 texPos = vec2((1.0 / SCREEN_PIXEL_SIZE.x) * UV.x, (1.0 / SCREEN_PIXEL_SIZE.y) * UV.y);
+	ivec2 savedTexPos = ivec2(texPos);
 	//distance between player and current pixel, which is also used to find the direction for the raycast
 	vec2 vector = (playerPos - texPos);
-	if(vector.x * vector.x + vector.y * vector.y < radius * radius)
+	int foundInside = 1; 
+	if(vector.x * vector.x + vector.y * vector.y < radius * heartbeat * radius * heartbeat)
 	{
-		bool foundInside =false;
-		
+		foundInside += 2;
 		//retrieves color of object map, testing to see if it is 
-		float pixelObjectColor = texelFetch(objectMap, ivec2(texPos), 0).x == 1.0 ? 1.0 : 0.0;
 		
 		//signed distance float, to find the distance from the nearest occluder
 		float sdfReturn = texture_sdf(texPos);
-		if(sdfReturn < 0.0 || texture_sdf(playerPos) < 0.0){//this means the point is inside an occluder
+		if(sdfReturn < 0.0 ||texture_sdf(playerPos) < 0.0){//this means the point is inside an occluder or the player is inside an occluder, oh no
 			//un comment all Color assignments and comment all actually used ones to see pixel values
 			
 			//COLOR = vec4(1.0, 0.0, 0.0, 1.0);//red
+			foundInside = 7;
 		}
 		else{// point is outside occluder test for it
 			//COLOR = vec4(1.0, 1.0, 0.0, 1.0);//yellow this color is assigned if the point is near and tracing along an edge, because it is constantly in a vector field of near 0, but it needs to keep on going from that point
@@ -45,28 +50,46 @@ void fragment() {
 				lengthToCenter = length(playerPos - texPos);
 				if(lengthToCenter < hitTargetD){//found the center, close as hittarget
 					i = maxStep;
+					--foundInside; 
 					//COLOR = vec4(0.0, 0.0, 0.0, 1.0);//black
-					foundInside = true;
 				}
 				sdfReturn = texture_sdf(texPos);
 				if(sdfReturn < insideOccluder){//point is inside occluder, with a error check value of insideOccluder
-					i = maxStep;
+					i = maxStep; 
+					foundInside = 5; 
 					//COLOR = vec4(1.0);//white
 				}
 				++i;
 			}
 		}
-		if(foundInside){//need to move this outside to make it cover whole screen (both the if and else statement)
-			
-			COLOR = texture(SCREEN_TEXTURE, SCREEN_UV) * (objectColor * pixelObjectColor);
-			//COLOR = vec4(1.0);
-
-		}
-		else{
-			COLOR *= darkNessColor;
-		}
 		
 	}
+	vec4 buffer = texture(SCREEN_TEXTURE, SCREEN_UV);
+	vec4 basePixelColor = texture(SCREEN_TEXTURE, SCREEN_UV);
+	if(foundInside > 1){//inside circle check for object to render
+		ivec2 texPos2 = ivec2(int((1.0 / SCREEN_PIXEL_SIZE.x) * UV.x), int((1.0 / SCREEN_PIXEL_SIZE.y) * UV.y));
+		vec4 pixel = texelFetch(objectMap, texPos2, 0);
+		buffer = texelFetch(objectMap, ivec2(int((1.0 / SCREEN_PIXEL_SIZE.x) * UV.x), int((1.0 / SCREEN_PIXEL_SIZE.y) * UV.y)), 0);
+		//screen texture alpha channel is never zero, so you can't test for that, instead you need to see if its equal to the base color, which is this
+		if(pixel.a == 1.0 && pixel.b != 0.0){
+			//basePixelColor = mix(buffer, objectColor, 2.0);
+			basePixelColor = mix(pixel, objectColor, objectIntensity);
+		}
+		//basePixelColor = buffer;
+	}
+	COLOR = mix(basePixelColor, darkNessColor, float(foundInside % 2) * darknessIntesity);
+	//COLOR = mix(basePixelColor, darkNessColor, 1.0);
+	//basePixelColor = basePixelColor;
+	//COLOR = mix(basePixelColor, darkNessColor, 0.0);
+	if(basePixelColor.a != 1.0){//this checks if the alphachannel is bellow 1.0
+		COLOR = vec4(basePixelColor.a);
+	}
+	//use mix to mix colors, do not multiply as then alpha channels cannot be adjusted, thus the multiplication looks pretty bad, I don't know what mix does but it works
+	if(foundInside < 1){
+		//COLOR = vec4(float(foundInside % 2));
+	}
+	
+	
 	
 	// Place fragment code here.
 }

--- a/Assets/Shader/Normal.gdshader
+++ b/Assets/Shader/Normal.gdshader
@@ -3,6 +3,7 @@ shader_type canvas_item;
 uniform sampler2D myArray;
 uniform vec4 object;
 uniform vec4 background;
+const vec4 clearBackground = vec4(0.0);
 
 //set this to whatever the null background color will be, right now it is 76
 const float noColorBackground = (76.0 / 255.0);
@@ -23,6 +24,6 @@ void fragment() {
 	//but the color is set to black if the null color is found, and white if any other is found, so we create a texture map where all objects are colored white
 	// and nothing is colored black, which we can use to apply shaders to certain objects, like for the heartbeat mechanic, or for lighting
 	//oh also the camera doesnt render anything that is not in its cull list, notes on that in NormalMap.txt
-	COLOR = (pixel.b == noColorBackground && pixel.g == noColorBackground && pixel.g == noColorBackground) ? background : object;
+	COLOR = pixel.b == 76.0 / 255.0 ? vec4(1.0, 0.0, 0.0, 1.0) : pixel;
 
 }

--- a/Assets/Shader/OverlayShader.gdshader
+++ b/Assets/Shader/OverlayShader.gdshader
@@ -2,16 +2,13 @@ shader_type canvas_item;
 
 uniform sampler2D myViewport;
 
-uniform float objectColor;
-
-uniform vec4 displayTestTrue;
-uniform vec4 displayTestFalse;
 
 void fragment() {
 	// Place fragment code here.
 	//this is just a shader to check if the normal map is working for now, in the future this shader will be what the overlay is
 	ivec2 texPos = ivec2(int((1.0 / SCREEN_PIXEL_SIZE.x) * UV.x), int((1.0 / SCREEN_PIXEL_SIZE.y) * UV.y));
 	vec4 pixel = texelFetch(myViewport, texPos, 0);
-	COLOR = (pixel.b == objectColor || pixel.g == objectColor || pixel.g == objectColor) ? displayTestTrue : displayTestFalse;
+	COLOR = pixel.a == 1.0 ? vec4(1.0) : pixel ;
+	//COLOR = vec4(float(texPos.y) * SCREEN_PIXEL_SIZE.y);
 	
 }

--- a/GameObjects/NormalViewportCreator.tscn
+++ b/GameObjects/NormalViewportCreator.tscn
@@ -15,6 +15,7 @@ shader_parameter/background = Vector4(0, 0, 0, 0)
 shader_parameter/myArray = SubResource("ViewportTexture_1kdyl")
 
 [node name="NormalViewport" type="SubViewport"]
+canvas_cull_mask = 4293918723
 script = ExtResource("1_58bjy")
 rLayer = 1
 
@@ -24,9 +25,10 @@ offset_right = 40.0
 offset_bottom = 40.0
 
 [node name="Camera2D" type="Camera2D" parent="."]
+visibility_layer = 2
 
 [node name="WatchViewPort" type="SubViewport" parent="."]
-canvas_cull_mask = 4294966272
+canvas_cull_mask = 4293918720
 size = Vector2i(1024, 600)
 script = ExtResource("3_os14o")
 renderLayer = 1
@@ -34,4 +36,5 @@ renderLayer = 1
 [node name="OverlayCamera" type="Camera2D" parent="WatchViewPort"]
 top_level = true
 light_mask = 1023
+visibility_layer = 1048575
 z_index = 1

--- a/Notes/NormalMap.txt
+++ b/Notes/NormalMap.txt
@@ -9,3 +9,10 @@ which if you need one look at the normalviewportcreater.tscn for an example. the
 
 
 just in case someone else wanted to use this, but also just ask me (bennett), if you need any help
+
+
+
+
+VERY VERY IMPROTANT
+TO USE THIS NODE, AND FOR AN OBJECT TO SHOW UP IN THE NODE ALL PARENTS OF SAID OBJECT NEED TO BE ON THE RENDER LAYER
+THAT MEANS EVEN THE MAIN GAME NODE NEEDS TO BE ON THE RENDER LAYER, SO YOU CANNOT HAVE A CHILD THAT IS AN OBJECT BUT NOT A PARENT

--- a/Scenes/GameTest.tscn
+++ b/Scenes/GameTest.tscn
@@ -1,28 +1,34 @@
-[gd_scene load_steps=10 format=3 uid="uid://bwgk5kdyur8dg"]
+[gd_scene load_steps=11 format=3 uid="uid://bwgk5kdyur8dg"]
 
+[ext_resource type="Script" path="res://Scenes/HeartBeatProvider.gd" id="1_2t6se"]
 [ext_resource type="Script" path="res://Scripts/OverlayScript.gd" id="1_8g1m0"]
-[ext_resource type="Shader" path="res://Assets/Shader/HeartBeat.gdshader" id="2_u3bex"]
+[ext_resource type="Shader" path="res://Assets/Shader/HeartBeat.gdshader" id="2_fninu"]
 [ext_resource type="PackedScene" uid="uid://dyodbn3o0xp07" path="res://GameObjects/NormalViewportCreator.tscn" id="3_ldimv"]
 [ext_resource type="Script" path="res://Scripts/HeartBeatFunc.gd" id="4_xtsij"]
 [ext_resource type="OccluderPolygon2D" uid="uid://doyfjyigk22eh" path="res://Assets/LightOccluder2d/MyOccluder.tres" id="5_mverf"]
 [ext_resource type="OccluderPolygon2D" uid="uid://cbqpjopequ4wo" path="res://Assets/LightOccluder2d/SlimeRightColored_Occ.tres" id="6_lwqaj"]
 
-[sub_resource type="ViewportTexture" id="ViewportTexture_ttigh"]
+[sub_resource type="ViewportTexture" id="ViewportTexture_t116x"]
 viewport_path = NodePath("NormalMapViewPort")
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_3euvh"]
 resource_local_to_scene = true
-shader = ExtResource("2_u3bex")
+shader = ExtResource("2_fninu")
 shader_parameter/playerPos = Vector2(240, 175)
 shader_parameter/radius = 40.0
-shader_parameter/objectColor = Vector4(0.85, 0.2, 0.085, 0.2)
-shader_parameter/darkNessColor = null
-shader_parameter/objectMap = SubResource("ViewportTexture_ttigh")
+shader_parameter/objectIntensity = 0.5
+shader_parameter/objectColor = Vector4(0.25, 0.5, 0, 1)
+shader_parameter/darknessIntesity = 0.7
+shader_parameter/darkNessColor = Vector4(0, 0, 0, 1)
+shader_parameter/heartbeat = 0.0
+shader_parameter/objectMap = SubResource("ViewportTexture_t116x")
 
 [sub_resource type="ViewportTexture" id="ViewportTexture_4ox7s"]
 viewport_path = NodePath(".")
 
 [node name="GameTest" type="Node2D"]
+visibility_layer = 3
+script = ExtResource("1_2t6se")
 
 [node name="PlayerCamera" type="Camera2D" parent="."]
 light_mask = 0
@@ -37,10 +43,12 @@ offset_right = 308.0
 offset_bottom = 464.0
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
+visible = false
 follow_viewport_enabled = true
 script = ExtResource("1_8g1m0")
 
 [node name="ColorRect" type="ColorRect" parent="CanvasLayer"]
+visibility_layer = 3
 material = SubResource("ShaderMaterial_3euvh")
 offset_right = 1152.0
 offset_bottom = 647.0
@@ -51,13 +59,26 @@ light_mask = 0
 offset_right = 40.0
 offset_bottom = 40.0
 
+[node name="ColorRect" type="ColorRect" parent="ColorRect"]
+visibility_layer = 2
+layout_mode = 0
+offset_left = -84.7556
+offset_top = 253.718
+offset_right = -44.7556
+offset_bottom = 293.718
+scale = Vector2(8.62496, 2.5)
+
 [node name="ColorRect2" type="ColorRect" parent="."]
+visibility_layer = 2
 offset_left = 240.0
 offset_top = 175.0
 offset_right = 280.0
 offset_bottom = 215.0
+scale = Vector2(1.14118, 1.00473)
 
 [node name="NormalMapViewPort" parent="." instance=ExtResource("3_ldimv")]
+canvas_cull_mask = 4293918721
+rLayer = 2
 
 [node name="HeartBeatFunc" type="CanvasLayer" parent="." node_paths=PackedStringArray("playerRef")]
 visible = false
@@ -71,7 +92,7 @@ offset_bottom = 648.0
 color = Color(1, 1, 1, 0)
 
 [node name="LightOccluder2D" type="LightOccluder2D" parent="."]
-position = Vector2(239, 180)
+position = Vector2(240, 150)
 occluder = ExtResource("5_mverf")
 
 [node name="LightOccluder2D2" type="LightOccluder2D" parent="."]

--- a/Scenes/HeartBeatProvider.gd
+++ b/Scenes/HeartBeatProvider.gd
@@ -1,0 +1,15 @@
+extends Node2D
+
+var time:float = 0;
+var heartBeat:float = 0;
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	time += delta;
+	heartBeat = abs(sin(time))
+	#print(heartBeat)
+	pass

--- a/Scenes/SubViewport.gd
+++ b/Scenes/SubViewport.gd
@@ -1,0 +1,12 @@
+extends SubViewport
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	print(self.canvas_cull_mask)
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass

--- a/Scripts/HeartBeatFunc.gd
+++ b/Scripts/HeartBeatFunc.gd
@@ -15,6 +15,8 @@ func _ready():
 	
 	var overlay:ColorRect = self.get_child(0)
 	
+	
+	
 	overlay.size = mainVP.size
 	pass # Replace with function body.
 

--- a/Scripts/NormalViewport.gd
+++ b/Scripts/NormalViewport.gd
@@ -21,9 +21,14 @@ func _ready():
 	var watchVP:Viewport = self.get_child(2)
 	
 	print(watchVP.name)
-	print(watchVP.canvas_cull_mask)
-	watchVP.set_canvas_cull_mask_bit(rLayer - 1, true)
-	print(watchVP.canvas_cull_mask)
+	#print(watchVP.canvas_cull_mask)
+	#watchVP.set_canvas_cull_mask_bit(2, false)
+	#watchVP.set_canvas_cull_mask_bit(0, false)
+	#watchVP.set_canvas_cull_mask_bit(4, false)
+	#watchVP.set_canvas_cull_mask_bit(rLayer, true)
+	#watchVP.set_canvas_cull_mask_bit(2, true)
+	watchVP.set_canvas_cull_mask_bit(rLayer -1 , true)
+	#print(watchVP.canvas_cull_mask)
 	
 	pass # Replace with function body.
 

--- a/Scripts/OverlayScript.gd
+++ b/Scripts/OverlayScript.gd
@@ -1,12 +1,21 @@
 extends CanvasLayer
 
-
+var childMat:ShaderMaterial;
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	self.visible = true
+	childMat = self.get_child(0).material
+	#self.get_child(0).get_material().set_shader_parameter("objectMap",self.get_parent().get_child(6).get_viewport())
+	self.visible = true;
+	#ib.set_shader_param(self.get_parent().get_child(6).get_viewport())
+	# = self.get_parent().get_child(6).get_viewport()
+	
+	#get_tree().get_root().get_viewport().set_canvas_cull_mask_bit(1, false);
+	
 	pass # Replace with function body.
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
+	print(self.get_parent().heartBeat)
+	childMat.set_shader_parameter("heartbeat", self.get_parent().heartBeat)
 	pass

--- a/Scripts/WatchViewPort.gd
+++ b/Scripts/WatchViewPort.gd
@@ -17,6 +17,9 @@ func _ready():
 	
 	camera.zoom = ogViewPort.get_camera_2d().zoom
 	camera.position = ogViewPort.get_camera_2d().position
+	#self.set_canvas_cull_mask_bit(4, false);
+	#for n in 20:
+	#	self.set_canvas_cull_mask_bit(n + 2, false);
 	#self.canvas_cull_mask = 0
 	
 	pass # Replace with function body.


### PR DESCRIPTION
I have "finished" the heartbeat shader. The heartbeat expands based on and sin, to continually detract and expand, the shader takes "three maps" and turns it into one. It takes first the sdf (signed distance map) and checks that map for intersects when ray-casting towards the player. The second map is then used to determine if an object will adjust the be inside the circle, and if it applys a different mix tot hat pixel the object is in. The third map is the original screen-texture and it is used for all non-object or outside of the radius pixels. 